### PR TITLE
Migrate to OCI repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM flownative/base:bookworm
+FROM ubuntu:latest
 
-# For Helm releases see: https://github.com/helm/helm/releases
-ENV HELM_VERSION v3.16.1
+ENV HELM_VERSION=v3.16.1
 ENV HELM_HOME=/root/.helm
 
-# We need Git for "helm plugin install"
 RUN apt-get update \
-    && apt-get install git \
+    && apt-get install git curl -y \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/log/apt \
     && rm -rf /var/log/dpkg.log
 
-RUN curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar xz \
+# For Helm releases see: https://github.com/helm/helm/releases
+RUN curl -sSL "https://get.helm.sh/helm-v3.16.1-linux-amd64.tar.gz" | tar xz \
     && mv linux-amd64/helm /usr/local/bin/helm \
     && rm -rf linux-amd64
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@ This is the actual implementation of the
 The actual GitHub action refers to a pre-built image in its
 `Dockerfile`, so that the action image does not have to be re-built on
 every use.
+
+## Testing
+
+To test this action locally, build the image and run the container as follows:
+
+```shell
+docker buildx build --platform linux/amd64 \
+  --tag flownative/action-helm-release:dev --load .
+
+docker run --name workflow --rm \
+  -e INPUT_APP_VERSION=2.133.1+5 
+  -e INPUT_CHART_VERSION=2.133.1+5 \
+  -e INPUT_REGISTRY_HOST=dev.harbor.example.com \
+  -e INPUT_REPOSITORY_PATH=acme-charts \
+  -e INPUT_CHART_NAME=beach-my-app \
+  -e INPUT_CHARTS_FOLDER=/application/Helm \
+  -e INPUT_REPOSITORY_USER=robot#acme-charts+github-test \
+  -e INPUT_REPOSITORY_PASSWORD=… \
+  -v=$(pwd):/application docker.io/flownative/action-helm-release:dev
+```


### PR DESCRIPTION
Chart Museum support was dropped and instead this action now assumes and supports that the registry is OCI compatible. See the README for the new set of input variables.